### PR TITLE
Fix: Corregido error en SECRET_KEY en settings.py

### DIFF
--- a/decide/decide/settings.py
+++ b/decide/decide/settings.py
@@ -20,7 +20,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/2.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = '^##ydkswfu0+=ofw0l#$kv^8n)0$i(qd&d&ol#p9!b$8*5%j1+
+SECRET_KEY = '^##ydkswfu0+=ofw0l#$kv^8n)0$i(qd&d&ol#p9!b$8*5%j1+'
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
## Descripción
Se corrige un error de sintaxis en `SECRET_KEY` de `settings.py` donde faltaba una comilla final. Esto causaba un error de tipo `SyntaxError`.

## Cambios realizados
- Añadida comilla faltante en `SECRET_KEY`.

## Issue relacionada
Closes #1

## Rama de cambios
- `egc_test`
